### PR TITLE
Add URL to package metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ version = attr: kubernetes_wsgi.__version__
 description = A wrapper for running your Python web application using Twisted in a way that works well for Kubernetes.
 long_description = file: README.md
 license = Apache License 2.0
+url = https://github.com/coderanger/kubernetes-wsgi
 classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3


### PR DESCRIPTION
Add URL to package metadata so PyPI (and other tools) can link directly back to the github project