### PR TITLE
Remove server version from header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ dist
 docs/_build/
 htmlcov
 pip-wheel-metadata
+.vscode
+.venv

--- a/src/kubernetes_wsgi/__main__.py
+++ b/src/kubernetes_wsgi/__main__.py
@@ -60,6 +60,11 @@ def parse_args(argv: Sequence[Text]) -> Dict[str, Any]:
         default=20,
         help="Maximum number of threads to run",
     )
+    parser.add_argument(
+        "--hide-server",
+        action="store_true",
+        help="Hides server version in HTTP header"
+    )
     args = parser.parse_args(argv)
     return {
         "application": args.application,
@@ -68,6 +73,7 @@ def parse_args(argv: Sequence[Text]) -> Dict[str, Any]:
         "health_check_path": args.health_check_path,
         "min_threads": args.min_threads,
         "max_threads": args.max_threads,
+        "hide_server": args.hide_server,
     }
 
 

--- a/src/kubernetes_wsgi/server.py
+++ b/src/kubernetes_wsgi/server.py
@@ -12,7 +12,6 @@ from twisted.internet.protocol import Factory  # type: ignore
 from twisted.logger import STDLibLogObserver  # type: ignore
 from twisted.python import threadpool  # type: ignore
 from twisted.web.http import Request, proxiedLogFormatter  # type: ignore
-import twisted.web.http
 from twisted.web.server import Site  # type: ignore
 from twisted.web.wsgi import WSGIResource  # type: ignore
 


### PR DESCRIPTION
Added a --hide-server header flag when executing from command line

Can keep server version when wanting to develop or debug, but can hide it from headers for security reasons